### PR TITLE
[A11y] 基本的无障碍支持

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -23,7 +23,7 @@
         <ul class="menu bg-base-100 rounded-box fixed bottom-16 right-3 w-max drop-shadow">
             <li>
                 <!-- 历史错误信息 -->
-                <Modal>
+                <Modal realButtonLabel="历史错误信息">
                     <div slot="open-modal" aria-hidden="true">
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
@@ -65,7 +65,7 @@
             
             <li>
                 <!-- 关于 -->
-                <Modal>
+                <Modal realButtonLabel="关于">
                     <div slot="open-modal" aria-hidden="true">
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
                     </div>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -22,13 +22,13 @@
     </div>
         <ul class="menu bg-base-100 rounded-box fixed bottom-16 right-3 w-max drop-shadow">
             <li>
+                <!-- 历史错误信息 -->
                 <Modal>
-                    <a slot="open-modal">
+                    <div slot="open-modal" aria-hidden="true">
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                         </svg>
-                    </a>
-
+                    </div>
                     <div slot="box" class="px-4 border-b rounded-t sm:px-6">
                         <div class="bg-white my-2 shadow sm:rounded-md">
                             <ul class="divide-y divide-gray-200">
@@ -61,13 +61,14 @@
                         </p>
                     </div>
                 </Modal>
-
             </li>
+            
             <li>
+                <!-- 关于 -->
                 <Modal>
-                    <a slot="open-modal">
+                    <div slot="open-modal" aria-hidden="true">
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-                    </a>
+                    </div>
                     <div slot="box" class="">
                         <h1 class="text-2xl font-bold text-center">
                             biliup-app

--- a/src/Append.svelte
+++ b/src/Append.svelte
@@ -48,12 +48,12 @@
             <label class="swap swap-rotate ml-2" on:click={sortVideos}>
 
                 <!-- this hidden checkbox controls the state -->
-                <input type="checkbox" bind:checked="{order}"/>
+                <input aria-label="排序视频" type="checkbox" bind:checked="{order}" />
 
-                <svg xmlns="http://www.w3.org/2000/svg" class="swap-off fill-current h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="swap-off fill-current h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
                 </svg>
-                <svg xmlns="http://www.w3.org/2000/svg" class="swap-on fill-current h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="swap-on fill-current h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
                 </svg>
             </label>

--- a/src/Drag-and-drop.svelte
+++ b/src/Drag-and-drop.svelte
@@ -72,7 +72,7 @@
     <label class="flex flex-col items-center justify-center cursor-pointer rounded-lg border-2 border-dashed w-full h-full p-5 group text-center"
            on:click={fileselect}>
 
-        <img alt="freepik image" class="max-h-48 object-center" src="image-upload-concept-landing-page.png">
+        <img aria-hidden="true"   alt="freepik image" class="max-h-48 object-center" src="image-upload-concept-landing-page.png">
 
         <p class="mt-4 text-gray-500 "><span class="text-sm">拖拽</span> 视频到此处 <br/>或者从你的电脑中<a
                 class="text-blue-600 hover:underline">选择</a></p>

--- a/src/Login.svelte
+++ b/src/Login.svelte
@@ -228,15 +228,21 @@
                 </div>
                 <button class="btn btn-block mt-2.5" on:click={login_by_sms}>登录</button>
             {/if}
+
+            <!-- 用户名密码登录按钮 -->
             <div class="flex items-center justify-between mt-4">
                 <span class="w-1/5 border-b dark:border-gray-600 lg:w-1/5"></span>
-
-                <a on:click={() => loginMethod='password'} href="#" class="text-xs text-center text-gray-500 uppercase dark:text-gray-400 hover:underline">若登录失败，尝试其他登录方式</a>
+                <a on:click={() => loginMethod='password'} 
+                    on:keydown={() => loginMethod='password'}
+                    role="button"
+                    aria-label="用户名密码登录"
+                    href="#" class="text-xs text-center text-gray-500 uppercase dark:text-gray-400 hover:underline">若登录失败，尝试其他登录方式</a>
 
                 <span class="w-1/5 border-b dark:border-gray-400 lg:w-1/5"></span>
             </div>
 
             <div class="flex items-center mt-6 -mx-2">
+                <!-- 短信登录按钮 -->
                 <button type="button" on:click={() => loginMethod = "sms"}
                         class="flex items-center justify-center w-full px-6 py-2 mx-2 text-sm font-medium text-white transition-colors duration-200 transform bg-blue-500 rounded-md hover:bg-blue-400 focus:bg-blue-400 focus:outline-none">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -245,6 +251,7 @@
                     <span class="hidden mx-2 sm:inline">短信登录</span>
                 </button>
 
+                <!-- 扫码登录按钮 -->
                 <button type="button" on:click={loginByQrcode}
                    class="flex items-center justify-center px-6 py-2 mx-2 w-full text-sm font-medium text-gray-500 transition-colors duration-200 transform bg-gray-300 rounded-md hover:bg-gray-200">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/src/Login.svelte
+++ b/src/Login.svelte
@@ -245,7 +245,7 @@
                     <span class="hidden mx-2 sm:inline">短信登录</span>
                 </button>
 
-                <a href="#" on:click={loginByQrcode}
+                <button type="button" on:click={loginByQrcode}
                    class="flex items-center justify-center px-6 py-2 mx-2 w-full text-sm font-medium text-gray-500 transition-colors duration-200 transform bg-gray-300 rounded-md hover:bg-gray-200">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z" />
@@ -256,7 +256,7 @@
 <!--                        </path>-->
 <!--                    </svg>-->
                     <span class="hidden mx-2 sm:inline">扫码登录</span>
-                </a>
+                </button>
             </div>
         </div>
     </div>

--- a/src/Login.svelte
+++ b/src/Login.svelte
@@ -170,17 +170,19 @@
                     </button>
                 </div>
                 <form>
-                    <label class="block text-sm text-gray-800">用户名</label>
-                    <input bind:value={username} class="block w-full px-4 py-2 mt-2 text-gray-700 bg-white border rounded-md focus:border-blue-500 focus:outline-none focus:ring"
-                               type="text">
-
                     <div class="mt-4">
-                        <div class="flex items-center justify-between">
-                            <label class="block text-sm text-gray-800" for="password">密码</label>
-                        </div>
-
-                        <input bind:value={password} class="block w-full px-4 py-2 mt-2 text-gray-700 bg-white border rounded-md focus:border-blue-500 focus:outline-none focus:ring"
-                               type="password">
+                        <label class="block text-sm text-gray-800" for="username">用户名</label>
+                        <input id="username"
+                            bind:value={username} 
+                            class="block w-full px-4 py-2 mt-2 text-gray-700 bg-white border rounded-md focus:border-blue-500 focus:outline-none focus:ring"
+                            type="text">
+                    </div>
+                    <div class="mt-4">
+                        <label class="block text-sm text-gray-800" for="password">密码</label>
+                        <input id="password"
+                            bind:value={password} 
+                            class="block w-full px-4 py-2 mt-2 text-gray-700 bg-white border rounded-md focus:border-blue-500 focus:outline-none focus:ring"
+                            type="password">
                     </div>
                     <label class="flex items-center mt-4">
                         <input bind:checked={rememberMe} class="form-checkbox" type="checkbox"/>

--- a/src/Login.svelte
+++ b/src/Login.svelte
@@ -206,13 +206,13 @@
                     </label>
                     <div class="flex">
                         <input type="text" placeholder="国家代码"  bind:value={countryCode} class="input input-bordered w-[5.75rem]">
-                        <input type="text" placeholder="phone numbers"  bind:value={telephone} class="input ml-2 w-full">
+                        <input type="text" placeholder="手机号"  bind:value={telephone} class="input ml-2 w-full">
                     </div>
                     <label class="label">
                         <span class="label-text">验证码</span>
                     </label>
                     <div class="relative">
-                        <input type="text" placeholder="verification code"  bind:value={verificationCode} class="w-full pr-16 input input-primary">
+                        <input type="text" placeholder="验证码"  bind:value={verificationCode} class="w-full pr-16 input input-primary">
                         <button on:click={sendSms} class:loading={throttle}  disabled={throttle}
                                 class="absolute top-0 right-0 rounded-l-none btn btn-primary">
                             {#if !throttle}

--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -4,6 +4,9 @@
 
 <script>
     import {onMount} from "svelte";
+    /// 键盘可操作按钮的名称
+    export let realButtonLabel="";
+
     let topDiv;
     let componentId = totalComponents++;
     onMount(() => {
@@ -22,7 +25,8 @@
 <!-- Put this part before </body> tag -->
 <!-- 实际的 checkbox 与弹窗 -->
 <div bind:this={topDiv}>
-    <input type="checkbox" id="component-modal-{componentId}" 
+    <input type="checkbox" id="component-modal-{componentId}"
+        aria-label="{realButtonLabel}"
         role="button"
         class="modal-toggle">
     <label for="component-modal-{componentId}" class="modal cursor-pointer">

--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -10,9 +10,12 @@
         document.body.appendChild(topDiv);
     });
 </script>
+
 <!-- The button to open modal -->
+<!-- 占位显示标签 -->
 <label for="component-modal-{componentId}" class="modal-button">
-    <slot name="open-modal">
+    <!-- NOTE for `aria-hidden`: 此处的标签实际上键盘不可操作，故忽略 -->
+    <slot name="open-modal" aria-hidden="true">
     </slot>
 </label>
 

--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -20,15 +20,18 @@
 </label>
 
 <!-- Put this part before </body> tag -->
+<!-- 实际的 checkbox 与弹窗 -->
 <div bind:this={topDiv}>
-    <input type="checkbox" id="component-modal-{componentId}" class="modal-toggle">
+    <input type="checkbox" id="component-modal-{componentId}" 
+        role="button"
+        class="modal-toggle">
     <label for="component-modal-{componentId}" class="modal cursor-pointer">
         <label class="modal-box">
             <slot name="box" componentId="component-modal-{componentId}">
+                <!-- 默认的显示内容 -->
                 <h3 class="text-lg font-bold">Congratulations random Interner user!</h3>
                 <p class="py-4">You've been selected for a chance to get one year of subscription to use Wikipedia for free!</p>
             </slot>
         </label>
     </label>
 </div>
-

--- a/src/Progress.svelte
+++ b/src/Progress.svelte
@@ -52,12 +52,14 @@
         <!--        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />-->
         <!--    </svg>-->
         <!--{:else }-->
-        <svg class="svg m-auto h-7 w-7" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+        <svg aria-hidden="true" class="svg m-auto h-7 w-7" fill="none" stroke="currentColor" viewBox="0 0 24 24"
              xmlns="http://www.w3.org/2000/svg">
             <path d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" stroke-linecap="round" stroke-linejoin="round"
                   stroke-width="2"/>
         </svg>
-        <svg class="del animate-bounce m-auto h-7 w-7" fill="currentColor" on:click={remove}
+        <svg class="del animate-bounce m-auto h-7 w-7" fill="currentColor"
+             aria-label="删除文件"
+             on:click={remove} on:keyup={remove}
              viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path clip-rule="evenodd"
                   d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
@@ -70,22 +72,22 @@
         <div class="flex">
             <span class="w-full">
                 <div class="flex w-full justify-between">
-                    <input bind:value="{file.title}" class="bg-inherit w-full truncate"/>
+                    <input aria-label="文件名" bind:value="{file.title}" class="bg-inherit w-full truncate"/>
                     <!--{title}-->
-                    <div class="text-gray-500 min-w-fit text-sm">{(totalSize/1024/1024).toFixed(2)} MiB</div>
+                    <div aria-label="文件大小" class="text-gray-500 min-w-fit text-sm">{(totalSize/1024/1024).toFixed(2)} MiB</div>
                 </div>
-                <span class="block max bg-yellow-300 border-yellow-300 border-opacity-60 border rounded-full" class:complete={!complete}
+                <span aria-hidden="true" class="block max bg-yellow-300 border-yellow-300 border-opacity-60 border rounded-full" class:complete={!complete}
                       style="width: {$fitProgress}%;"></span>
             </span>
         </div>
     </div>
     <div class="flex-none flex flex-col w-20 h-12 justify-center items-center text-gray-500 font-mono text-xs">
         <!-- This item will not grow -->
-        <div>
+        <div aria-label="上传速度">
             <!--{Math.round($fitSpeed * 100) / 100} MB/s-->
             {$fitSpeed.toFixed(2)} MB/s
         </div>
-        <div>
+        <div aria-label="上传进度">
             {$fitProgress.toFixed(2)} %
         </div>
     </div>

--- a/src/Sidebar.svelte
+++ b/src/Sidebar.svelte
@@ -179,7 +179,7 @@
     <div class="flex items-center justify-between">
         <div class="flex items-center flex-none">
             <Modal>
-                <img slot="open-modal" class="object-cover rounded-full h-9 w-9 cursor-pointer hover:ring-2 hover:ring-purple-600 hover:ring-offset-2" src="{face}" alt="avatar"/>
+                <img slot="open-modal" class="object-cover rounded-full h-9 w-9 cursor-pointer hover:ring-2 hover:ring-purple-600 hover:ring-offset-2" src="{face}" alt="头像"/>
                 <div slot="box" let:componentId>
                     <label for="{componentId}" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
                     <label for="{componentId}" on:click={processNewUser} class="group block max-w-xs mx-auto rounded-lg p-2 bg-white ring-1 ring-slate-900/5 shadow-lg space-y-3 hover:bg-sky-500 hover:ring-sky-500">

--- a/src/Sidebar.svelte
+++ b/src/Sidebar.svelte
@@ -208,7 +208,9 @@
                         {/each}
                     </ul>
                     <div class="modal-action">
-                        <label for="{componentId}" on:click={processChangeUser} class="btn">切换账号</label>
+                        <label for="{componentId}" on:click={processChangeUser} 
+                            role="button" title="切换账号"
+                            class="btn">切换账号</label>
                     </div>
                 </div>
             </Modal>
@@ -232,14 +234,18 @@
                     <h4>上传线路选择：</h4>
                     <div class="btn-group">
                         {#each lines as l}
-                            <input type="radio" bind:group={line} value="{l}" data-title="{l}" class="btn btn-outline btn-xs">
+                            <input type="radio" bind:group={line} title="{l}" value="{l}" data-title="{l}" class="btn btn-outline btn-xs">
                         {/each}
                     </div>
                 </div>
 
                 <div class="modal-action">
-                    <label for="{componentId}" on:click={saveSettings} class="btn btn-accent">Save</label>
-                    <label for="{componentId}" class="btn">Close</label>
+                    <label for="{componentId}" on:click={saveSettings} 
+                        title="保存设置"
+                        class="btn btn-accent">Save</label>
+                    <label for="{componentId}" 
+                        title="关闭设置"
+                        class="btn">Close</label>
                 </div>
             </div>
         </Modal>

--- a/src/Sidebar.svelte
+++ b/src/Sidebar.svelte
@@ -178,8 +178,11 @@
      transition:fly={{delay: 400, x: -100}}>
     <div class="flex items-center justify-between">
         <div class="flex items-center flex-none">
-            <Modal>
-                <img slot="open-modal" class="object-cover rounded-full h-9 w-9 cursor-pointer hover:ring-2 hover:ring-purple-600 hover:ring-offset-2" src="{face}" alt="头像"/>
+            <!-- 账号切换 -->
+            <Modal realButtonLabel="账号切换">
+                <img slot="open-modal" class="object-cover rounded-full h-9 w-9 cursor-pointer hover:ring-2 hover:ring-purple-600 hover:ring-offset-2" 
+                    aria-hidden="true"
+                    src="{face}" alt="头像"/>
                 <div slot="box" let:componentId>
                     <label for="{componentId}" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
                     <label for="{componentId}" on:click={processNewUser} class="group block max-w-xs mx-auto rounded-lg p-2 bg-white ring-1 ring-slate-900/5 shadow-lg space-y-3 hover:bg-sky-500 hover:ring-sky-500">
@@ -219,8 +222,8 @@
             </div>
         </div>
 
-        <Modal>
-            <a slot="open-modal" class="flex cursor-pointer tooltip items-center" data-tip="设置" on:click={loadSettings} >
+        <Modal realButtonLabel="设置">
+            <a slot="open-modal" class="flex cursor-pointer tooltip items-center" data-tip="设置" on:click={loadSettings} aria-hidden="true">
                 <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                     <path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd" />
                 </svg>
@@ -284,9 +287,10 @@
         </nav>
 
         <div class="sticky bottom-0 bg-inherit">
-            <Modal>
+            <Modal realButtonLabel="编辑现有稿件或新建投稿模板">
                 <a slot="open-modal" class="mt-2.5 mb-5 py-2 px-4 flex justify-center items-center bg-green-500 hover:bg-green-700 focus:ring-green-500 focus:ring-offset-green-200 text-white w-full transition ease-in duration-200 text-center text-base font-semibold shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2  rounded-full"
-                        type="button">
+                    aria-hidden="true"
+                    type="button">
                     <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"
                          xmlns="http://www.w3.org/2000/svg">
                         <path d="M12 4v16m8-8H4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>

--- a/src/Sidebar.svelte
+++ b/src/Sidebar.svelte
@@ -303,18 +303,18 @@
                     <div class="form-control w-full max-w-xs">
                         <label class="label">
                             <span class="label-text">输入BV或av号可编辑现有稿件</span>
-                            <span class="label-text-alt">av971158452</span>
+                            <span aria-hidden="true" class="label-text-alt">av971158452</span>
                         </label>
                         <input type="text" bind:value={tempName} placeholder="{'未命名模板' + Object.keys($template).length}" class="input input-bordered w-full max-w-xs" />
                         <label class="label">
                             <span class="label-text-alt">输入其他将新建投稿模板</span>
-                            <span class="label-text-alt">BV1ip4y1x7Gi</span>
+                            <span aria-hidden="true"  class="label-text-alt">BV1ip4y1x7Gi</span>
                         </label>
                     </div>
 
                     <div class="modal-action">
                         <label for="{componentId}" on:click={add} class="btn btn-accent">添加模板</label>
-                        <label for="{componentId}" class="btn">Close</label>
+                        <label aria-hidden="true"  for="{componentId}" class="btn">Close</label>
                     </div>
                 </div>
             </Modal>

--- a/src/Sidebar.svelte
+++ b/src/Sidebar.svelte
@@ -213,7 +213,7 @@
                 </div>
             </Modal>
             <div data-tip="打开配置文件夹" class="tooltip">
-                <h4 on:click={openConfigDir} class="ml-2 font-medium text-gray-800 hover:underline truncate max-w-[8rem]">{name}</h4>
+                <button on:click={openConfigDir} class="ml-2 font-medium text-gray-800 hover:underline truncate max-w-[8rem]">{name}</button>
             </div>
         </div>
 

--- a/src/Sidebar.svelte
+++ b/src/Sidebar.svelte
@@ -263,8 +263,9 @@
         <nav class="">
             {#each items as item(item)}
 
-                <a animate:flip="{{duration: 300}}" class:selected="{$currentTemplate.current === item}"
+                <button animate:flip="{{duration: 300}}" class:selected="{$currentTemplate.current === item}"
                    on:click="{() => select(item)}">
+                   <div class="flex flex-row">
                     {#if ($template[item].changed)}
                         <span class="flex absolute h-1.5 w-1.5 top-0 right-0 flex">
                           <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-purple-400 opacity-75"></span>
@@ -284,7 +285,8 @@
                         </svg>
                         <span class="ml-4 font-medium truncate">{item}</span>
                     {/if}
-                </a>
+                    </div>
+                </button>
 
             {/each}
         </nav>

--- a/src/Sidebar.svelte
+++ b/src/Sidebar.svelte
@@ -185,14 +185,15 @@
                     src="{face}" alt="头像"/>
                 <div slot="box" let:componentId>
                     <label aria-hidden="true" for="{componentId}" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
-                    <label for="{componentId}" on:click={processNewUser} class="group block max-w-xs mx-auto rounded-lg p-2 bg-white ring-1 ring-slate-900/5 shadow-lg space-y-3 hover:bg-sky-500 hover:ring-sky-500">
+                    <label for="{componentId}" on:click={processNewUser} on:keyup={processNewUser}
+                    class="group block max-w-xs mx-auto rounded-lg p-2 bg-white ring-1 ring-slate-900/5 shadow-lg space-y-3 hover:bg-sky-500 hover:ring-sky-500">
                         <div class="flex items-center space-x-3">
                             <svg aria-hidden="true" class="h-6 w-6 stroke-sky-500 group-hover:stroke-white" fill="none" viewBox="0 0 24 24">
                                 <!--                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">-->
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
                                 <!--                        </svg>-->
                             </svg>
-                            <h3 class="text-slate-900 group-hover:text-white text-sm font-semibold">注销并添加新账号</h3>
+                            <button class="text-slate-900 group-hover:text-white text-sm font-semibold">注销并添加新账号</button>
                         </div>
                     </label>
                     <ul role="list" class="p-6 divide-y divide-slate-200">
@@ -211,7 +212,9 @@
                         {/each}
                     </ul>
                     <div class="modal-action">
-                        <label for="{componentId}" on:click={processChangeUser} 
+                        <label for="{componentId}" 
+                            on:click={processChangeUser} 
+                            on:keyup={processChangeUser}
                             role="button" title="切换账号"
                             class="btn">切换账号</label>
                     </div>

--- a/src/Sidebar.svelte
+++ b/src/Sidebar.svelte
@@ -184,10 +184,10 @@
                     aria-hidden="true"
                     src="{face}" alt="头像"/>
                 <div slot="box" let:componentId>
-                    <label for="{componentId}" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
+                    <label aria-hidden="true" for="{componentId}" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
                     <label for="{componentId}" on:click={processNewUser} class="group block max-w-xs mx-auto rounded-lg p-2 bg-white ring-1 ring-slate-900/5 shadow-lg space-y-3 hover:bg-sky-500 hover:ring-sky-500">
                         <div class="flex items-center space-x-3">
-                            <svg class="h-6 w-6 stroke-sky-500 group-hover:stroke-white" fill="none" viewBox="0 0 24 24">
+                            <svg aria-hidden="true" class="h-6 w-6 stroke-sky-500 group-hover:stroke-white" fill="none" viewBox="0 0 24 24">
                                 <!--                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">-->
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
                                 <!--                        </svg>-->
@@ -199,7 +199,7 @@
                         {#each people as person}
                             <!-- Remove top/bottom padding when first/last child -->
                             <li class="flex items-center py-0.5 first:pt-0 last:pb-0 ">
-                                <img class="h-8 w-8 rounded-full" src="{person.face}" alt="" />
+                                <img aria-hidden="true" class="h-8 w-8 rounded-full" src="{person.face}" alt="" />
                                 <div class="form-control w-full mx-2">
                                     <label class="label cursor-pointer">
                                         <span class="label-text">{person.name}</span>

--- a/src/Upload.svelte
+++ b/src/Upload.svelte
@@ -335,8 +335,11 @@
                         </div>
                     {/if}
                 </label>
+                <!-- 模板保存与删除 -->
                 <div class="flex flex-row-reverse">
-                    <button class="ml-2 py-2 px-2 flex justify-center items-center bg-red-600 hover:bg-red-700 focus:ring-red-500 focus:ring-offset-red-200 text-white transition ease-in duration-200 text-center text-base font-semibold shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2  w-8 h-8 rounded-lg " on:click|preventDefault={del}
+                    <button class="ml-2 py-2 px-2 flex justify-center items-center bg-red-600 hover:bg-red-700 focus:ring-red-500 focus:ring-offset-red-200 text-white transition ease-in duration-200 text-center text-base font-semibold shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2  w-8 h-8 rounded-lg " 
+                            on:click|preventDefault={del}
+                            title="删除当前模板"
                             type="button">
                         <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"
                              xmlns="http://www.w3.org/2000/svg">
@@ -344,7 +347,9 @@
                                   stroke-width="2"/>
                         </svg>
                     </button>
-                    <button class="py-2 px-2 flex justify-center items-center bg-blue-600 hover:bg-blue-700 focus:ring-blue-500 focus:ring-offset-blue-200 text-white transition ease-in duration-200 text-center text-base font-semibold shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2  w-8 h-8 rounded-lg " on:click|preventDefault={save}
+                    <button class="py-2 px-2 flex justify-center items-center bg-blue-600 hover:bg-blue-700 focus:ring-blue-500 focus:ring-offset-blue-200 text-white transition ease-in duration-200 text-center text-base font-semibold shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2  w-8 h-8 rounded-lg " 
+                            on:click|preventDefault={save}
+                            title="保存当前模板"
                             type="button">
                         <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"
                              xmlns="http://www.w3.org/2000/svg">

--- a/src/Upload.svelte
+++ b/src/Upload.svelte
@@ -396,25 +396,30 @@
                 {/if}
             </div>
 
-
-            <div class="flex w-52" use:archivePre={{callback, current, currentChildren}}>
-                <button class="border border-gray-300 relative w-full bg-white rounded-md pl-3 pr-10 py-3 text-left cursor-default focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+            <!-- 分区选择 -->
+            <div class="flex w-52">
+                <!-- https://kabbouchi.github.io/tippyjs-v4-docs/accessibility/ -->
+                <div use:archivePre={{callback, current, currentChildren}}>
+                    <button class="border border-gray-300 relative w-full bg-white rounded-md pl-3 pr-10 py-3 text-left cursor-default focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                        title="分区选择"    
+                        aria-expanded="false"
                         type="button">
-                    <span class="flex items-center">
-                        <span class="ml-1 block truncate">
-                            {parent} → {children}
+                        <span class="flex items-center">
+                            <span class="ml-1 block truncate">
+                                {parent} → {children}
+                            </span>
                         </span>
-                    </span>
-                    <span class="ml-3 absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-                        <svg aria-hidden="true" class="h-5 w-5 text-gray-400" fill="currentColor"
-                             viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                            <path clip-rule="evenodd"
-                                  d="M10 3a1 1 0 01.707.293l3 3a1 1 0 01-1.414 1.414L10 5.414 7.707 7.707a1 1 0 01-1.414-1.414l3-3A1 1 0 0110 3zm-3.707 9.293a1 1 0 011.414 0L10 14.586l2.293-2.293a1 1 0 011.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z"
-                                  fill-rule="evenodd">
-                            </path>
-                        </svg>
-                    </span>
-                </button>
+                        <span class="ml-3 absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
+                            <svg aria-hidden="true" class="h-5 w-5 text-gray-400" fill="currentColor"
+                                viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                                <path clip-rule="evenodd"
+                                    d="M10 3a1 1 0 01.707.293l3 3a1 1 0 01-1.414 1.414L10 5.414 7.707 7.707a1 1 0 01-1.414-1.414l3-3A1 1 0 0110 3zm-3.707 9.293a1 1 0 011.414 0L10 14.586l2.293-2.293a1 1 0 011.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z"
+                                    fill-rule="evenodd">
+                                </path>
+                            </svg>
+                        </span>
+                    </button>
+                </div>
                 <!--                <input bind:this={archivePre} bind:value={tid} type="text" class=" rounded-lg border-transparent flex-1 appearance-none border border-gray-300 w-full py-2 px-4 bg-white text-gray-700 placeholder-gray-400 shadow-sm text-base focus:outline-none focus:ring-2 focus:ring-purple-600 focus:border-transparent" placeholder="分区"/>-->
             </div>
 

--- a/src/Upload.svelte
+++ b/src/Upload.svelte
@@ -457,13 +457,16 @@
                           class="textarea textarea-bordered w-full"
                           cols="40" placeholder="动态描述" rows="1"></textarea>
             </div>
-            
+
+            <!-- 定时发布 -->
             <div class="flex items-center">
-                <input type="checkbox" class="toggle my-2" bind:checked="{isDtime}">
-                <span class="ml-2 text-sm font-bold text-gray-500 tracking-wide">开启定时发布</span>
+                <label class="label">
+                    <input type="checkbox" class="toggle my-2" bind:checked="{isDtime}">
+                    <span class="ml-2 text-sm font-bold text-gray-500 tracking-wide" >开启定时发布</span>
+                </label>
                 {#if (isDtime)}
-                    <input class="mx-3 border rounded-lg border-gray-300 py-1 px-2" type="date" bind:value={date}/>
-                    <input class="mx-3 border rounded-lg border-gray-300 py-1 px-2" type="time" bind:value={time}/>
+                    <input class="mx-3 border rounded-lg border-gray-300 py-1 px-2" type="date" bind:value={date} title="定时发布日期（年/月/日）" />
+                    <input class="mx-3 border rounded-lg border-gray-300 py-1 px-2" type="time" bind:value={time} title="定时发布时间（小时:分钟）" />
                 {/if}
             </div>
             {#if (autoSubmit)}

--- a/src/Upload.svelte
+++ b/src/Upload.svelte
@@ -350,9 +350,13 @@
                     </button>
                 </div>
             </div>
+            
+            <!-- 视频标题 -->
             <input bind:value={selectedTemplate.title}
                    class="bg-[#f9fcfd] w-full text-base p-2 border border-gray-300 rounded-lg focus:outline-none focus:border-indigo-500"
-                   placeholder="标题">
+                   placeholder="视频标题">
+
+            <!-- 视频上传 -->
             <Append selectedTemplate="{selectedTemplate}"/>
             <p class="text-sm text-gray-300" title="允许上传的视频后缀">
                 File type: .mp4,.flv,.avi,.wmv,.mov,.webm,.mpeg4,.ts,.mpg,.rm,.rmvb,.mkv,.m4v

--- a/src/Upload.svelte
+++ b/src/Upload.svelte
@@ -417,11 +417,13 @@
                 </button>
                 <!--                <input bind:this={archivePre} bind:value={tid} type="text" class=" rounded-lg border-transparent flex-1 appearance-none border border-gray-300 w-full py-2 px-4 bg-white text-gray-700 placeholder-gray-400 shadow-sm text-base focus:outline-none focus:ring-2 focus:ring-purple-600 focus:border-transparent" placeholder="分区"/>-->
             </div>
+
+            <!-- 视频标签 -->
             <div class="flex flex-wrap rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-purple-600 focus:border-transparent">
                 {#each tags as tag(tag)}
                     <span animate:flip="{{duration: 300}}" class="flex  ml-1 my-1.5 px-3 py-0.5 text-base rounded-full text-white  bg-indigo-500 ">
                         {tag}
-                        <button on:click={(e)=>{removeTag(tag)}} class="bg-transparent hover">
+                        <button on:click={(e)=>{removeTag(tag)}} class="bg-transparent hover" title="删除{tag}标签" >
                             <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor"
                                  class="ml-2" viewBox="0 0 1792 1792">
                                 <path d="M1490 1322q0 40-28 68l-136 136q-28 28-68 28t-68-28l-294-294-294 294q-28 28-68 28t-68-28l-136-136q-28-28-28-68t28-68l294-294-294-294q-28-28-28-68t28-68l136-136q28-28 68-28t68 28l294 294 294-294q28-28 68-28t68 28l136 136q28 28 28 68t-28 68l-294 294 294 294q28 28 28 68z">
@@ -432,7 +434,8 @@
                 {/each}
 
                 <input bind:value={tempTag} class="outline-none rounded-lg flex-1 appearance-none  w-full py-2 px-4 bg-white text-gray-700 placeholder-gray-400 shadow-sm text-base " on:keypress={e=>e.key==='Enter' && handleKeypress()}
-                       placeholder="标签，回车输入"
+                       placeholder="视频标签，回车输入"
+                       title="输入标签名后按回车添加标签；通过标签的删除按钮删除标签"
                        type="text"/>
             </div>
 

--- a/src/Upload.svelte
+++ b/src/Upload.svelte
@@ -312,22 +312,26 @@
 <div in:fly="{{ y: 200, duration: 400 }}">
     <div class="px-6 pt-3 pb-10 my-2 mr-12" >
         <div class="space-y-3">
+            <!-- 模板 -->
             <div class="flex justify-between">
+                <!-- 模板标题 -->
                 <label class="text-lg font-bold tracking-wide mb-2">
                     {#if (edit)}
                         <input on:focusout={()=> update(false)} bind:value={selected}
                                class="w-full p-1 border border-gray-300 rounded-lg focus:outline-none focus:border-indigo-500"
-                               placeholder="标题">
+                               placeholder="模板标题">
                     {:else}
                         <div class="p-1">
                             {selected}
-                            <svg on:click={()=> update(true)}
-                                 xmlns="http://www.w3.org/2000/svg"
+                            <button on:click|preventDefault={()=> update(true)}
+                                 title="模板标题编辑按钮" >
+                            <svg xmlns="http://www.w3.org/2000/svg"
                                  class="cursor-pointer inline h-5 w-5 hover:text-blue-700" fill="none"
                                  viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                       d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"/>
                             </svg>
+                            </button>
                         </div>
                     {/if}
                 </label>

--- a/src/Upload.svelte
+++ b/src/Upload.svelte
@@ -354,9 +354,11 @@
                    class="bg-[#f9fcfd] w-full text-base p-2 border border-gray-300 rounded-lg focus:outline-none focus:border-indigo-500"
                    placeholder="标题">
             <Append selectedTemplate="{selectedTemplate}"/>
-            <p class="text-sm text-gray-300">
+            <p class="text-sm text-gray-300" title="允许上传的视频后缀">
                 File type: .mp4,.flv,.avi,.wmv,.mov,.webm,.mpeg4,.ts,.mpg,.rm,.rmvb,.mkv,.m4v
             </p>
+
+            <!-- 视视频封面 -->
             <div class="app">
                 <FilePond bind:this={pond} {name}
                           labelIdle="{labelIdle}"
@@ -367,6 +369,8 @@
                           acceptedFileTypes="image/png, image/jpeg, image/gif"
                           />
             </div>
+
+            <!-- 转载声明 -->
             <div class="bg-[#fafcfd] border rounded-md px-2 py-1">
                 <div class="mb-3 flex justify-between items-center">
                     <!--                <div>-->

--- a/src/Upload.svelte
+++ b/src/Upload.svelte
@@ -435,22 +435,29 @@
                        placeholder="标签，回车输入"
                        type="text"/>
             </div>
+
+            <!-- 视频简介 -->
             <div class="text-gray-700">
-                <label class="label">
+                <label class="label" for="bv-intro">
                     <span class="text-sm font-bold text-gray-500 tracking-wide">简介</span>
                 </label>
                 <textarea bind:value={selectedTemplate.desc}
+                          id="bv-intro"
                           class="textarea textarea-bordered w-full"
                           cols="40" placeholder="简介补充: ..." rows="4"></textarea>
             </div>
+
+            <!-- 粉丝动态描述 -->
             <div class="text-gray-700">
-                <label class="label">
+                <label class="label" for="bv-dynamic-desc">
                     <span class="text-sm font-bold text-gray-500 tracking-wide">粉丝动态</span>
                 </label>
                 <textarea bind:value={selectedTemplate.dynamic}
+                          id="bv-dynamic-desc"
                           class="textarea textarea-bordered w-full"
                           cols="40" placeholder="动态描述" rows="1"></textarea>
             </div>
+            
             <div class="flex items-center">
                 <input type="checkbox" class="toggle my-2" bind:checked="{isDtime}">
                 <span class="ml-2 text-sm font-bold text-gray-500 tracking-wide">开启定时发布</span>

--- a/src/common.ts
+++ b/src/common.ts
@@ -27,6 +27,8 @@ export function archivePre(node, combine) {
         plugins: [animateFill],
         inertia: true,
         interactive: true,
+        aria: null,
+        appendTo: 'parent',
         onCreate(instance) {
 
             partition = new Partition({
@@ -60,6 +62,12 @@ export function archivePre(node, combine) {
         },
         onDestroy(instance) {
             off();
+        },
+        onMount({ reference }) {
+            reference.setAttribute('aria-expanded', 'true')
+        },
+        onHide({ reference }) {
+            reference.setAttribute('aria-expanded', 'false')
         },
     });
     return {


### PR DESCRIPTION
虽然准备换用新前端了。但毕竟还要一段时间。
我就先在这边的基础上修了一下。
发一个 pr 以供后人参考

xref: https://github.com/ForgQi/biliup-app/issues/62


## 主要的修改
- label 与 输入控件要互相关联。登录页的账号、密码就是很好的例子。
- 没有描述文本的重要节点，通过 aria-label 添加无障碍描述
- 为了美观而无实际功能的节点通过 aria-hidden="true" 在无障碍树中隐藏
- 尽可能地使用语义上正确的节点类型，比如是按钮就用 button。
	如果用其他类型 a/div 等模拟，就还要考虑键盘操作的问题。
	例如：button 默认可以用空格键按下。
- 参考 tippy.js 的文档开启了弹窗的无障碍
- Modal
	- 给 Modal 多加了个参数，用作隐藏的 checkbox 节点的名字
	- 把 Modal 对应可见的控件，从无障碍树中隐藏。对应的功能通过不可见的 checkbox 进行
	- 这里弹窗的按钮因为是 input 格式的，没法用键盘操作，所以我在其他分支上做了 hack ，直接新加了很多真正的按钮

## 仍存在的问题
- 发送验证码按下后，暂停时间不可读
- 弹窗的按钮基本都无法使用，因为不是正常的 button
- 分区选择，用键盘操作只能选主分区，无法选择细分分区
- 侧边栏弹出提示，不会被视障者感受到。需要有文本或声音提示
- 其他待深入测试...

不过这些也不着急修了，因为现在这样就基本可用。
可以在写新前端时就考虑一些无障碍的设计，提前规避一些坑。

## 参考
- ARIA无障碍网页应用属性 速查 http://h-ui.net/Hui-notes-ARIA.shtml
- 常见的 a11y 警告及改正方法 https://open-wc.org/docs/linting/eslint-plugin-lit-a11y/overview/
- 浏览器插件: WAVE Evaluation Tool
- chrome 开发者工具：元素/辅助功能/启用整页辅助功能树。然后再元素的右上角点击按钮开启
	这棵树就是视障者眼中的网页

其他的备注
- 另外如果想要自己尝试屏幕阅读器，推荐使用开源的 https://nvdacn.com/ 
- 操作网页时是仅限键盘，一般通过方向键（上下左右）和 TAB/shift+TAB 来导航然后回车/空格选择。
- 建议主要使用方向键进行操作，TAB 键跳过的东西太多了
- 纯键盘操作参考 https://webaim.org/techniques/keyboard/#testing